### PR TITLE
Wrap get.sh with ()

### DIFF
--- a/res/get.sh
+++ b/res/get.sh
@@ -7,37 +7,39 @@ set -e
 #     `wget -qO- <url-to-get.sh> | sh`
 #
 
-# Check for valid operating systems and machines.
-if [ "`uname -s -p`" != "Linux x86_64" ]; then
-    echo "error: Unsupported operating system '`uname -s -p`';"
-    echo "       Only 'Linux x86_64' supported at the moment."
-    #exit 1
-fi
+# Wrap in () to prevent execution if connection is interrupted.
+(
+    # Check for valid operating systems and machines.
+    if [ "`uname -s -p`" != "Linux x86_64" ]; then
+        echo "error: Unsupported operating system '`uname -s -p`';"
+        echo "       Only 'Linux x86_64' supported at the moment."
+        #exit 1
+    fi
 
-# make sure to sudo as necessary.
-sh_c='sh -c'
-if [ "$user" != 'root' ]; then
-    sh_c='sudo -E sh -c'
-fi
+    # make sure to sudo as necessary.
+    sh_c='sh -c'
+    if [ "$user" != 'root' ]; then
+        sh_c='sudo -E sh -c'
+    fi
 
-version=`curl -sSL https://raw.githubusercontent.com/joeduffy/blocker/master/res/LATEST`
-filename="blocker.$version.Linux-x86_64.tar.gz"
-download="https://github.com/joeduffy/blocker/releases/download/$version/$filename"
+    version=`curl -sSL https://raw.githubusercontent.com/joeduffy/blocker/master/res/LATEST`
+    filename="blocker.$version.Linux-x86_64.tar.gz"
+    download="https://github.com/joeduffy/blocker/releases/download/$version/$filename"
 
-echo "Downloading Blocker $version..."
-$sh_c "curl -sSL $download | tar xz"
+    echo "Downloading Blocker $version..."
+    $sh_c "curl -sSL $download | tar xz"
 
-echo "Installing Blocker..."
-$sh_c 'mv blocker /usr/local/bin/blocker'
-$sh_c 'chmod +x /usr/local/bin/blocker'
-$sh_c 'mkdir -p /etc/blocker/.aws'
-$sh_c 'mkdir -p /etc/docker/plugins'
-$sh_c 'echo "unix:///var/run/blocker.sock" > /etc/docker/plugins/blocker.spec'
-$sh_c 'mv blocker.service /etc/systemd/system/blocker.service'
+    echo "Installing Blocker..."
+    $sh_c 'mv blocker /usr/local/bin/blocker'
+    $sh_c 'chmod +x /usr/local/bin/blocker'
+    $sh_c 'mkdir -p /etc/blocker/.aws'
+    $sh_c 'mkdir -p /etc/docker/plugins'
+    $sh_c 'echo "unix:///var/run/blocker.sock" > /etc/docker/plugins/blocker.spec'
+    $sh_c 'mv blocker.service /etc/systemd/system/blocker.service'
 
-echo "Starting the Blocker service..."
-$sh_c 'systemctl enable /etc/systemd/system/blocker.service'
-$sh_c 'systemctl start blocker.service'
+    echo "Starting the Blocker service..."
+    $sh_c 'systemctl enable /etc/systemd/system/blocker.service'
+    $sh_c 'systemctl start blocker.service'
 
-echo "Done."
-
+    echo "Done."
+)


### PR DESCRIPTION
For secure execution to protect against
truncated files being executed in a curl|bash,
wrap code in get.sh with a () block.

Now, execution should not proceed until the trailing )
is received and the () block is parsed as valid syntax.
