### PR TITLE
implement volume tag detection to support services in Swarm mode

### DIFF
--- a/ebs_driver.go
+++ b/ebs_driver.go
@@ -65,6 +65,7 @@ func NewEbsVolumeDriver() (VolumeDriver, error) {
 }
 
 func (d *ebsVolumeDriver) Create(name string, opts map[string]string) error {
+
 	vol, exists := d.volumes[name]
 	if exists {
 		// Docker won't always cleanly remove entries.  It's okay so long
@@ -74,7 +75,17 @@ func (d *ebsVolumeDriver) Create(name string, opts map[string]string) error {
 		}
 	} else {
 		// Create a new volume, defaulting the ID to its name, and add it to the map.
-		vol = &ebsVolume{name: name, mount: "", volumeId: name}
+		volumeId := name
+		serviceName, exists := opts["service"]
+		if exists {
+			v, err := d.getAvailableVolumeForService(serviceName)
+			if err != nil {
+				return err
+			}
+			volumeId = *v.VolumeId
+		}
+
+		vol = &ebsVolume{name: name, mount: "", volumeId: volumeId}
 		d.volumes[name] = vol
 	}
 

--- a/filters.go
+++ b/filters.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+func (d *ebsVolumeDriver) getAvailableVolumeForService(serviceName string) (*ec2.Volume, error) {
+	result, err := d.ec2.DescribeVolumes(&ec2.DescribeVolumesInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name:   aws.String("status"),
+				Values: []*string{aws.String("available")},
+			},
+			&ec2.Filter{
+				Name:   aws.String("availability-zone"),
+				Values: []*string{aws.String(d.awsAvailabilityZone)},
+			},
+			&ec2.Filter{
+				Name:   aws.String("tag-key"),
+				Values: []*string{aws.String("service")},
+			},
+			&ec2.Filter{
+				Name:   aws.String("tag-value"),
+				Values: []*string{aws.String(serviceName)},
+			},
+		},
+	})
+
+	if len(result.Volumes) == 0 {
+		return nil, fmt.Errorf("no volume available for service %s", serviceName)
+	}
+
+	// just return the first available one
+	return result.Volumes[0], err
+}


### PR DESCRIPTION
This PR implements tag detection in an EBS volume in a form of `service=<name>`.
If matches, it will retrieve the volume id for the plugin to mount.
With this PR, we are allowed to provision something like a stateful MySQL Galera cluster with a Docker service. 

Example use case:
1. Tag a volume with "service=myservice". 
2. Run the following command.
```
sudo docker service create --name test \
 --log-driver=journald \
  --mount "type=volume,volume-driver=blocker,src=db,target=/root,volume-opt=service=myservice" \
  alpine top
```

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>